### PR TITLE
/snapshot endpoint fixed

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,8 +10,10 @@ app = Flask(__name__)
 @app.route('/snapshot')
 def snapshot():
     with open('datasets/symbols.csv') as f:
-        symbols = f.read().splitlines()
-        for symbol in symbols:
+        for line in f:
+            if "," not in line:
+                continue
+            symbol = line.split(",")[0]
             data = yf.download(symbol, start="2020-01-01", end="2020-08-01")
             data.to_csv('datasets/daily/{}.csv'.format(symbol))
 


### PR DESCRIPTION
I find your tutorials both high signal and entertaining. Keep on doing great work!

I encountered this bug with the `TA-Lib` app though. `/snapshot` endpoint produces these files:
```
...
	datasets/daily/ALB,Albemarle Corp.csv
	datasets/daily/ALGN,Align Technology.csv
	datasets/daily/ALK,Alaska Air Group Inc.csv
	datasets/daily/ALL,Allstate Corp.csv
	datasets/daily/ALLE,Allegion.csv
	datasets/daily/ALXN,Alexion Pharmaceuticals.csv
...
```

And `/` endpoint expects files in `datasets/daily` to be named in a certain way (`$ticker.csv`). As a results, the program is not working as intended.

The problem is obvious, fix tested with:
```
FLASK_APP="app.py" flask run
curl -v "http://127.0.0.1:5000/snapshot"
...
< HTTP/1.0 200 OK
< Content-Type: application/json
< Content-Length: 19
< Server: Werkzeug/1.0.1 Python/3.8.5
< Date: Mon, 10 Aug 2020 04:11:26 GMT
<
{"code":"success"}
```

Datasets have been downloaded as expected.